### PR TITLE
chore: automate festival and/or mpg123 packages installations

### DIFF
--- a/index.js
+++ b/index.js
@@ -54,6 +54,11 @@ module.exports = function (app) {
 
     if (process.platform === 'linux') {
       if (pluginProps.installAudioPkgs) {
+        try {
+          execSync('sudo apt update', {stdio: 'inherit'});
+        } catch (e) {
+          console.error(`${plugin.id}: Failed to run 'sudo apt update'. Please update your package lists manually.`);
+        }
         const pkgs = ['festival', 'mpg123'];
         pkgs.forEach(pkg => {
           try {

--- a/index.js
+++ b/index.js
@@ -54,16 +54,12 @@ module.exports = function (app) {
 
     if (process.platform === 'linux') {
       if (pluginProps.installAudioPkgs) {
-        try {
-          execSync('sudo apt update', {stdio: 'inherit'});
-        } catch (e) {
-          console.error(`${plugin.id}: Failed to run 'sudo apt update'. Please update your package lists manually.`);
-        }
         const pkgs = ['festival', 'mpg123'];
         pkgs.forEach(pkg => {
           try {
             execSync(`which ${pkg}`, {stdio: 'ignore'});
           } catch {
+            execSync('sudo apt update', {stdio: 'inherit'});
             const result = spawnSync('sudo', ['apt', 'install', '-y', pkg], {stdio: 'inherit'});
             if (result.status !== 0) {
               console.error(`${plugin.id}: Failed to install ${pkg}, install it manually and restart the plugin.`);

--- a/index.js
+++ b/index.js
@@ -53,19 +53,21 @@ module.exports = function (app) {
     if (!pluginProps.repeatGap) pluginProps.repeatGap = 0
 
     if (process.platform === 'linux') {
-      const pkgs = ['festival', 'mpg123'];
-      pkgs.forEach(pkg => {
-        try {
-          execSync(`which ${pkg}`, {stdio: 'ignore'});
-        } catch {
-          const result = spawnSync('sudo', ['apt', 'install', '-y', pkg], {stdio: 'inherit'});
-          if (result.status !== 0) {
-            console.error(`${plugin.id}: Failed to install ${pkg}, install it manually and restart the plugin.`);
-            process.exit(1);
+      if (pluginProps.installAudioPkgs) {
+        const pkgs = ['festival', 'mpg123'];
+        pkgs.forEach(pkg => {
+          try {
+            execSync(`which ${pkg}`, {stdio: 'ignore'});
+          } catch {
+            const result = spawnSync('sudo', ['apt', 'install', '-y', pkg], {stdio: 'inherit'});
+            if (result.status !== 0) {
+              console.error(`${plugin.id}: Failed to install ${pkg}, install it manually and restart the plugin.`);
+              process.exit(1);
+            }
+            console.log(`${plugin.id}: Installed missing package, ${pkg}`);
           }
-          console.log(`${plugin.id}: Installed missing package, ${pkg}`);
-        }
-      });
+        });
+      }
     }
     if (pluginProps.mappings)
       pluginProps.mappings.forEach((m) => {
@@ -578,6 +580,12 @@ module.exports = function (app) {
           title: 'Custom Command After Playing Notification',
           description: 'optional command to run after playing/speaking',
           type: 'string'
+        },
+        installAudioPkgs: {
+          title: 'Audio Packages, festival & mpg123 (Linux Only)',
+          description: 'Select to install missing audio packages',
+          type: 'boolean',
+          default: false
         },
         alarmAudioPlayer: {
           title: 'Audio Player',


### PR DESCRIPTION
If festival and/or mpg123 package are missing, plugin tries to install those. If sudo apt install  fails, then inform user same way as before.
Fix issue #5